### PR TITLE
Add bin executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"url": "https://github.com/medikoo/tad/issues"
 	},
 	"scripts": {
-		"test": "node ./bin/tad lib",
+		"test": "./bin/tad lib",
 		"lint": "node ./node_modules/jslint/bin/jslint.js --color --git"
 	},
   "bin": {


### PR DESCRIPTION
This will configure `tad` as an executable node script when it is installed.

If installed locally, it will install to `node_modules/.bin`, globally it will probably install tad somewhere on the PATH like: `/usr/local/bin/tad`
